### PR TITLE
fix color issue

### DIFF
--- a/hackthebox.zsh-theme
+++ b/hackthebox.zsh-theme
@@ -118,5 +118,6 @@ build_prompt() {
   prompt_end
 }
 
-PROMPT='%{%f%B%k%}$(build_prompt) '
+PROMPT='%{%f%B%k%}$(build_prompt) %{$reset_color%}'
 
+zle_highlight=( default:bold,fg=$green )


### PR DESCRIPTION
Hey! Thanks for the theme. I'm using it as part of my project, that makes Kali (not Parrot ;)) look like pwnbox.

Had issues with colors in some lines after the user input, e.g. when executing ``ls -l`:

![image](https://user-images.githubusercontent.com/22256963/152539099-4a4d3bfa-b294-4f63-938a-d75ae982d1dc.png)

As explained [here](https://github.com/ohmyzsh/ohmyzsh/issues/4042#issuecomment-114145634), there is a variable to configure the command line text color.